### PR TITLE
Upgrading to support Django 1.9

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,7 @@
+## 0.1.4 - Mar. 4 2016
+
+* Removing dependency on `request.REQUEST`.
+
 ## 0.1.3 - Oct. 22 2014
 
 * Adding support for function handlers.

--- a/methodview/__init__.py
+++ b/methodview/__init__.py
@@ -1,3 +1,4 @@
+"""Django Methodview."""
 #
 # Copyright 2012 keyes.ie
 #

--- a/methodview/accept_header.py
+++ b/methodview/accept_header.py
@@ -1,3 +1,4 @@
+"""Accept Header."""
 #
 # Copyright 2012 keyes.ie
 #
@@ -8,8 +9,10 @@ from .media_range import MediaRange
 
 
 class AcceptHeader(object):
+    """Representation of an Accept header."""
 
     def __init__(self, raw_header):
+        """Initialize the header."""
         self.media_ranges = []
 
         mranges = raw_header.split(',')
@@ -19,5 +22,6 @@ class AcceptHeader(object):
         self.media_ranges.sort(reverse=True)
 
     def __iter__(self):
+        """Iterate over the media ranges in the header."""
         for mr in self.media_ranges:
             yield mr

--- a/methodview/media_range.py
+++ b/methodview/media_range.py
@@ -1,3 +1,4 @@
+"""Media Range."""
 #
 # Copyright 2012 keyes.ie
 #
@@ -6,7 +7,10 @@
 
 
 class MediaRange(object):
+    """A MediaRange class."""
+
     def __init__(self, media_range):
+        """Initialize the object by parsing media ragnge."""
         if ';' in media_range:
             content_type, params = media_range.split(';', 1)
         else:
@@ -43,17 +47,21 @@ class MediaRange(object):
 
     @property
     def content_type(self):
+        """Return the content_type of the range."""
         return '%s/%s' % (self.mtype, self.subtype)
 
     @property
     def any_media(self):
+        """Return whether this range accepts any media."""
         return "*/*" == self.content_type
 
     @property
     def any_subtype(self):
+        """Return whether this range accepts any subtype."""
         return self.subtype == "*"
 
     def __lt__(self, other):
+        """Return whether this range is less than the `other` range."""
         if self == other:
             return False
         if self.quality == other.quality:
@@ -72,15 +80,18 @@ class MediaRange(object):
         return self.quality < other.quality
 
     def __gt__(self, other):
+        """Return whether this range is greater than the `other` range."""
         if not self == other:
             return not self < other
         return False
 
     def __eq__(self, other):
+        """Return whether this range is equal to the `other` range."""
         return self.mtype == other.mtype and \
             self.subtype == other.subtype and \
             self.quality == other.quality and \
             self.extensions == other.extensions
 
     def __str__(self):
+        """Return a string representation of this range."""
         return self._str

--- a/methodview/view.py
+++ b/methodview/view.py
@@ -92,8 +92,11 @@ class MethodView(object):
         else:
             accept = AcceptHeader(request.META['HTTP_ACCEPT'])
 
-        if '_method' in request.REQUEST:
-            method_name = request.REQUEST['_method']
+        # check in POST then GET for _method.
+        if '_method' in request.POST:
+            method_name = request.POST['_method']
+        elif '_method' in request.GET:
+            method_name = request.GET['_method']
 
         method_name = method_name.upper()
         if method_name in self._allowed_methods:

--- a/methodview/view.py
+++ b/methodview/view.py
@@ -1,3 +1,4 @@
+"""Django Method View."""
 # -*- coding: utf-8 -*-
 #
 # Copyright 2012 keyes.ie
@@ -15,6 +16,7 @@ ALLOWED_METHODS = ('GET', 'HEAD', 'POST', 'PUT')
 
 
 def hasmethod(obj, method_name):
+    """Check if `obj` has a callable attribute `method_name`."""
     if hasattr(obj, method_name):
         attr = getattr(obj, method_name)
         return inspect.ismethod(attr) or inspect.isfunction(attr)
@@ -22,22 +24,32 @@ def hasmethod(obj, method_name):
 
 
 class HttpResponseNotImplemented(HttpResponse):
+    """HttpResponse 501."""
+
     status_code = 501
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs):  # noqa
         HttpResponse.__init__(self, *args, **kwargs)
 
 
 class HttpResponseNotAcceptable(HttpResponse):
+    """HttpResponse 406."""
+
     status_code = 406
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs):  # noqa
         HttpResponse.__init__(self, *args, **kwargs)
 
 
 class MethodView(object):
+    """The MethodView class."""
 
     def __init__(self, allowed=None, accepts=None):
+        """Initialize the view.
+
+        * allowed - what methods are allowed
+        * accepts - what media types are accepted
+        """
         if allowed is None:
             allowed = ALLOWED_METHODS
         self._allowed_methods = [a.upper() for a in allowed]
@@ -80,9 +92,7 @@ class MethodView(object):
         return None
 
     def __call__(self, request, *args, **kwargs):
-        """
-        Method dispatcher.
-        """
+        """Method dispatcher."""
         method_name = request.method
         if 'HTTP_ACCEPT' not in request.META:
             # From: http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 Django
-nose==1.1.2
-mock==0.8.0
+mock==1.3.0
+nose==1.3.7

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools import setup
 
 setup(
     name="django-methodview",
-    version='0.1.3',
+    version='0.1.4',
     description="Class based HTTP method view",
     long_description=open('README').read(),
     author="John Keyes",

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -1,3 +1,4 @@
+"""Unit test package."""
 #
 # Copyright 2012 keyes.ie
 #

--- a/tests/unit/test_mediarange.py
+++ b/tests/unit/test_mediarange.py
@@ -1,3 +1,4 @@
+"""Test for media range."""
 #
 # Copyright 2012 keyes.ie
 #
@@ -9,20 +10,24 @@ from unittest import TestCase
 
 
 class MediaRangeTest(TestCase):
+    """Test media range parsing."""
 
     def test_any_media(self):
+        """Test for any media accepted."""
         media_range = MediaRange("*/*")
         self.assertEqual(media_range.content_type, "*/*")
         self.assertTrue(media_range.any_media)
         self.assertTrue(media_range.any_subtype)
 
     def test_any_subtype(self):
+        """Test for any subtype accepted."""
         media_range = MediaRange("image/*")
         self.assertEqual(media_range.content_type, "image/*")
         self.assertFalse(media_range.any_media)
         self.assertTrue(media_range.any_subtype)
 
     def test_png(self):
+        """Test for specific content type."""
         media_range = MediaRange("image/png")
         self.assertEqual(media_range.content_type, "image/png")
         self.assertEqual(media_range.mtype, "image")
@@ -31,12 +36,14 @@ class MediaRangeTest(TestCase):
         self.assertFalse(media_range.any_subtype)
 
     def test_invalid_asterix(self):
+        """Test invalid setitng - *."""
         media_range = MediaRange("*")
         self.assertEqual(media_range.content_type, "*/*")
         self.assertTrue(media_range.any_media)
         self.assertTrue(media_range.any_subtype)
 
     def test_invalid_media(self):
+        """Test an invalud setting - 'image'."""
         media_range = MediaRange("image")
         self.assertEqual(media_range.content_type, "image/*")
         self.assertEqual(media_range.mtype, "image")

--- a/tests/unit/test_view.py
+++ b/tests/unit/test_view.py
@@ -13,14 +13,9 @@ from unittest import TestCase
 os.environ['DJANGO_SETTINGS_MODULE'] = 'methodview.view'
 
 
-class MockRequest(Mock):
-
-    META = {}
-    REQUEST = {}
-
-    def __init__(self, method):
-        super(MockRequest, self).__init__()
-        self.method = method
+def create_request(method):
+    request = Mock(META={}, POST={}, GET={}, method=method)
+    return request
 
 
 class BasicMethodTest(TestCase):
@@ -35,11 +30,11 @@ class BasicMethodTest(TestCase):
     def test(self):
         view = BasicMethodTest.TestView()
 
-        request = MockRequest('GET')
+        request = create_request('GET')
         res = view(request)
         self.assertEqual('GOT', res)
 
-        request = MockRequest('POST')
+        request = create_request('POST')
         res = view(request)
         self.assertEqual('POSTED', res)
 
@@ -59,7 +54,7 @@ class AcceptHeaderTest(TestCase):
     def test(self):
         view = AcceptHeaderTest.TestView()
 
-        request = MockRequest('GET')
+        request = create_request('GET')
         res = view(request)
         self.assertEqual('GOT DEFAULT', res)
 

--- a/tests/unit/test_view.py
+++ b/tests/unit/test_view.py
@@ -1,3 +1,4 @@
+"""Tests for MethodView."""
 #
 # Copyright 2012 keyes.ie
 #
@@ -14,20 +15,27 @@ os.environ['DJANGO_SETTINGS_MODULE'] = 'methodview.view'
 
 
 def create_request(method):
+    """Creare a Mock HTTP Request."""
     request = Mock(META={}, POST={}, GET={}, method=method)
     return request
 
 
 class BasicMethodTest(TestCase):
+    """Test for method/verb support."""
 
     class TestView(MethodView):
+        """A Test view."""
+
         def get(self, request):
+            """Return GOT."""
             return 'GOT'
 
         def post(self, request):
+            """Return POSTED."""
             return 'POSTED'
 
     def test(self):
+        """Test GET and POST."""
         view = BasicMethodTest.TestView()
 
         request = create_request('GET')
@@ -40,18 +48,25 @@ class BasicMethodTest(TestCase):
 
 
 class AcceptHeaderTest(TestCase):
+    """Test for honouring `Accept` header."""
 
     class TestView(MethodView):
+        """Test View."""
+
         def get(self, request):
+            """Return 'GOT DEFAULT'."""
             return 'GOT DEFAULT'
 
         def get_text_html(self, request):
+            """Return 'GOT TEXT HTML'."""
             return 'GOT TEXT HTML'
 
         def get_application_json(self, request):
+            """Return 'GOT APPLICATION JSON'."""
             return 'GOT APPLICATION JSON'
 
     def test(self):
+        """Test `Accept` header."""
         view = AcceptHeaderTest.TestView()
 
         request = create_request('GET')


### PR DESCRIPTION
As request.REQUEST has been deprecated, it now explicitly checks in POST
first then GET.
